### PR TITLE
fix: automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,6 +3,9 @@ name: Auto Approve and Merge PRs
 on:
   pull_request:
   workflow_call:
+    secrets:
+      token:
+        required: true
 
 permissions:
   contents: write
@@ -10,7 +13,7 @@ permissions:
   checks: read
 
 env:
-  PR_URL: ${{github.event.pull_request.html_url}}
+  PR_URL: ${{ github.event.pull_request.html_url }}
 
 jobs:
   auto-approve-and-merge:
@@ -38,12 +41,12 @@ jobs:
             fi
           done
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.token }}
       - name: Enable auto-approve
         run: gh pr review --approve "$PR_URL"
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.token }}
       - name: Enable auto-merge
         run: gh pr merge --auto --merge "$PR_URL"
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
I used secrets instead of inputs because it's secure. With inputs the secrets is possible to be exposed in logs. This securely passes the token without exposing it.
Fixes [AB#21592](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/21592)