### PR TITLE
ci: add upgrade flakes workflow

### DIFF
--- a/.github/workflows/upgrade-flakes.yml
+++ b/.github/workflows/upgrade-flakes.yml
@@ -1,0 +1,24 @@
+name: "Upgrade flakes"
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+jobs:
+  flakes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v28


### PR DESCRIPTION
## Summary

- Add scheduled workflow to automatically update `flake.lock` inputs (nixpkgs, flake-utils, android, dev) on a weekly basis
- Mirrors the `upgrade-flakes` workflow pattern from [plumelo/dev](https://github.com/plumelo/dev/blob/master/.github/workflows/upgrade-flakes.yml)
- Triggers: weekly schedule (Sundays at midnight), `repository_dispatch`, and `workflow_dispatch`