### PR TITLE
feat: add foundry reusable workflow with changesets

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -1,0 +1,71 @@
+name: Foundry
+on:
+  workflow_call:
+    secrets:
+      token:
+        description: 'app token or pat'
+        required: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint commits
+        if: github.event_name == 'pull_request'
+        run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
+
+      - name: Lint code
+        run: npm run lint --if-present
+
+      - name: Build
+        run: npm run build --if-present
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm ls @playwright/test 2>/dev/null | grep @playwright/test | head -1 | sed 's/.*@playwright\/test@//')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright Browsers for Playwright's Version
+        id: cache-playwright-browsers
+        if: steps.playwright-version.outputs.version != ''
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+          restore-keys: ${{ runner.os }}-playwright-
+
+      - name: Setup Playwright
+        if: steps.playwright-version.outputs.version != '' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Test
+        run: npm test --if-present
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Create Release Pull Request or Publish
+        uses: changesets/action@v1
+        if: success() && github.event_name == 'push' && github.repository_owner == 'neovici'
+        with:
+          publish: npm run changeset publish
+          commit: "[ci] release"
+          title: "[ci] release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.token || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: 0


### PR DESCRIPTION
Add a new reusable GitHub Actions workflow (`foundry.yml`) that mirrors `forge.yml` but uses [Changesets](https://github.com/changesets/changesets) instead of semantic-release for versioning and publishing.

This is part of the org-wide migration from semantic-release to changesets to enable branch protection on `master`.

Fixes: FE-694