### PR TITLE
ci: remove playwright cache restore fallback

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
-          restore-keys: ${{ runner.os }}-playwright-
 
       - name: Setup Playwright
         if: steps.playwright-version.outputs.version != '' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- remove broad Playwright cache restore key from foundry workflow
- keep cache restores on exact Playwright version key only
- avoid restoring older browser caches that are immediately discarded

Relates to FE-694.