### PR TITLE
fix: change automerge default merge-method from --merge to --squash

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,7 +9,7 @@ on:
         default: '["dependabot[bot]"]'
       merge-method:
         type: string
-        default: '--merge'
+        default: '--squash'
     secrets:
       token:
         required: false


### PR DESCRIPTION
## Problem

The reusable automerge workflow at `.github/workflows/automerge.yml` uses `--merge` (merge commit) as the default merge method. However, the org-level **"Default: reviewable"** ruleset (id 11123166) restricts `allowed_merge_methods` to only `["squash"]` on the default branch.

This causes the automerge workflow to fail with:

```
GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)
```

## Affected repos

**11 repos currently have failing automerge runs:**

- cosmoz-bottom-bar, cosmoz-charts, cosmoz-component, cosmoz-input, cosmoz-omnitable-treenode-column, cosmoz-router, cosmoz-spinner, cosmoz-tabs, cosmoz-tree, cosmoz-treenode, cosmoz-viewinfo

**29 repos have the reviewable ruleset** and will fail on any new dependabot PR.

## Fix

Change the default `merge-method` input from `--merge` to `--squash`.

Fixes FE-943