### PR TITLE
fix: restore gitignore entries lost in previous commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+node_modules
+.eslintcache
+.direnv
+.envrc
+
 # Codecov uploader artifacts (downloaded by codecov-action to repo root)
 codecov
 codecov.SHA256SUM


### PR DESCRIPTION
The previous commit (87c51bf) overwrote .gitignore instead of appending.
This restores node_modules, .eslintcache, .direnv, .envrc entries.